### PR TITLE
add BeaconScanEvent in when expression

### DIFF
--- a/android/src/main/kotlin/de/motiontag/fluttertracker/MotionTagPlugin.kt
+++ b/android/src/main/kotlin/de/motiontag/fluttertracker/MotionTagPlugin.kt
@@ -11,6 +11,7 @@ import de.motiontag.tracker.LocationEvent
 import de.motiontag.tracker.MotionTag
 import de.motiontag.tracker.PowerSaveModeChangedEvent
 import de.motiontag.tracker.TransmissionEvent
+import de.motiontag.tracker.BeaconScanEvent
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
@@ -63,6 +64,7 @@ class MotionTagPlugin : FlutterPlugin, MethodCallHandler {
                 }
                 is BatteryOptimizationsChangedEvent -> {}
                 is PowerSaveModeChangedEvent -> {}
+                is BeaconScanEvent -> {}
             }
         }
 


### PR DESCRIPTION
with current repo android build fail with this error

[/MotionTagPlugin.kt:26:13](file:///Users/dago/.pub-cache/hosted/pub.dev/motiontag_sdk-0.1.1/android/src/main/kotlin/de/motiontag/fluttertracker/MotionTagPlugin.kt:26:13) 'when' expression must be exhaustive, add necessary 'is BeaconScanEvent' branch or 'else' branch instead

