### PR TITLE
Add missing namespace for gradle bundle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "de.motiontag.fluttertracker"
     compileSdkVersion 33
 
     sourceSets {


### PR DESCRIPTION
I have faced an issue while adding `motiontag_sdk` into our project, and this fix work on our case 

Here's the `pubspec.yaml` integration 

```
dependencies:
  motiontag_sdk: ^0.1.3
```

Here's the error details, happen while running `flutter build apk` or `flutter run appbundle`

```
Running Gradle task 'assembleRelease'...                        

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':motiontag_sdk'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 8s
Running Gradle task 'assembleRelease'...                            9.1s
Gradle task assembleRelease failed with exit code ```

